### PR TITLE
Add New Zealand North region.

### DIFF
--- a/labs/hub-and-spoke-azfw/locals.tf
+++ b/labs/hub-and-spoke-azfw/locals.tf
@@ -1,6 +1,6 @@
 locals {
   # Convert the region name to a unique abbreviation
-  region_abbreviations = {
+   region_abbreviations = {
     "australiacentral"   = "acl",
     "australiacentral2"  = "acl2",
     "australiaeast"      = "ae",
@@ -29,6 +29,7 @@ locals {
     "koreacentral"       = "krc",
     "koreasouth"         = "krs",
     "mexicocentral"      = "mxc",
+    "newzealandnorth"    = "nzn",
     "northcentralus"     = "ncus",
     "northeurope"        = "ne",
     "norwayeast"         = "nwe",

--- a/labs/hub-and-spoke-nva/locals.tf
+++ b/labs/hub-and-spoke-nva/locals.tf
@@ -29,6 +29,7 @@ locals {
     "koreacentral"       = "krc",
     "koreasouth"         = "krs",
     "mexicocentral"      = "mxc",
+    "newzealandnorth"    = "nzn",
     "northcentralus"     = "ncus",
     "northeurope"        = "ne",
     "norwayeast"         = "nwe",

--- a/labs/vwan-standard/locals.tf
+++ b/labs/vwan-standard/locals.tf
@@ -29,6 +29,7 @@ locals {
     "koreacentral"       = "krc",
     "koreasouth"         = "krs",
     "mexicocentral"      = "mxc",
+    "newzealandnorth"    = "nzn",
     "northcentralus"     = "ncus",
     "northeurope"        = "ne",
     "norwayeast"         = "nwe",


### PR DESCRIPTION
This pull request includes changes to add the "newzealandnorth" region to the `locals` blocks in multiple Terraform files. The most important changes are:

* [`labs/hub-and-spoke-azfw/locals.tf`](diffhunk://#diff-ebffa5399fe8671a17cb9f4590fbe7b6e6cf957a7cfd6ecd4cded2978a1ce651R32): Added "newzealandnorth" region with the abbreviation "nzn".
* [`labs/hub-and-spoke-nva/locals.tf`](diffhunk://#diff-ee00038351d6b04adcd929ee2d06da8a18268370122fc2f1690e18d0f6da01e0R32): Added "newzealandnorth" region with the abbreviation "nzn".
* [`labs/vwan-standard/locals.tf`](diffhunk://#diff-672393d7009037a00e11b3cc1867e74461c6366191df605d55a89b6df12701fbR32): Added "newzealandnorth" region with the abbreviation "nzn".